### PR TITLE
Cause services to restart if they exit

### DIFF
--- a/roles/matrix-sydent/templates/matrix-sydent.service.j2
+++ b/roles/matrix-sydent/templates/matrix-sydent.service.j2
@@ -5,6 +5,8 @@ Description="Matrix Identity Server (sydent)"
 ExecStart=/bin/bash -c "{{matrix_sydent_home}}/env/bin/python -m sydent.sydent"
 WorkingDirectory={{matrix_sydent_home}}
 User=sydent
+Group=sydent
+Restart=on-failure
 
 [Install]
 WantedBy=default.target

--- a/roles/matrix-synapse/templates/matrix-synapse.service.j2
+++ b/roles/matrix-synapse/templates/matrix-synapse.service.j2
@@ -8,6 +8,7 @@ ExecStart=/opt/synapse/env/bin/python -m synapse.app.homeserver --config-path=/o
 ExecStop=/opt/synapse/env/bin/synctl stop /opt/synapse/homeserver.yaml
 User=synapse
 Group=synapse
+Restart=always
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Both matrix-sydent and matrix-synapse should automatically restart if they stop without being explicitly shut down.